### PR TITLE
Release the webcam VideoCapture in demo.py

### DIFF
--- a/demo/demo.py
+++ b/demo/demo.py
@@ -119,6 +119,7 @@ if __name__ == "__main__":
             cv2.imshow(WINDOW_NAME, vis)
             if cv2.waitKey(1) == 27:
                 break  # esc to quit
+        cam.release()
         cv2.destroyAllWindows()
     elif args.video_input:
         video = cv2.VideoCapture(args.video_input)


### PR DESCRIPTION
As per the documentation of OpenCV, one should free the allocated resources (using `VideoCapture.release()`) when done with the webcam.

The current `demo.py` forgets to do this. This pull request fixes it.